### PR TITLE
Introduce CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Ruby
-        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f33b7eb52773b5ed1
+        uses: ruby/setup-ruby@v1
       - name: Install dependencies
         run: bundle install
       - name: Run CI


### PR DESCRIPTION
Configures a Rakefile with a default task to run RSpec and standard.

Ran `bundle exec rspec --init` to generate `spec/spec_helper.rb` and
`.rspec`.

Additionally, we add a GitHub Action to run this default task based on
a [starter Ruby workflow][1].

[1]: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-ruby#using-the-ruby-starter-workflow